### PR TITLE
:white_check_mark: (show) test happy path

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,9 @@ pip install pre-commit
 pip install -r requirements-dev.txt -U
 pre-commit install
 ```
+
+### testing
+
+```bash
+pytest
+```

--- a/nowplaying/show/client.py
+++ b/nowplaying/show/client.py
@@ -19,8 +19,6 @@ from . import show
 
 logger = logging.getLogger("now-playing")
 
-DEFAULT_SHOW_NAME = "Sendung gemäss Programm"
-DEFAULT_SHOW_URL = "http://www.rabe.ch"
 DEFAULT_SHOW_DURATION = 30  # 30 seconds
 
 

--- a/nowplaying/show/show.py
+++ b/nowplaying/show/show.py
@@ -14,7 +14,7 @@ import pytz
 
 logger = logging.getLogger("now-playing")
 
-DEFAULT_SHOW_URL = "http://www.rabe.ch"
+DEFAULT_SHOW_URL = "https://www.rabe.ch"
 
 
 class ShowError(Exception):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,3 +11,4 @@ isort==4.3.4
 pytest==4.1.1
 pytest-cov==2.6.1
 pytest-env==0.6.2
+mock=2.0.0

--- a/tests/fixtures/cast_now_during_show.xml
+++ b/tests/fixtures/cast_now_during_show.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<cast_now version="120826" created="2017-11-18T19:22:01+0100" created_int="20171118192201">
+  <real_name>Voice of Hindu Kush</real_name>
+  <duration_h>1</duration_h>
+  <start_time>2019-01-27T14:00:00+01:00</start_time>
+  <end_time>2319-01-27T15:00:00+01:00</end_time>
+  <url>https://www.rabe.ch/stimme-der-kutuesch/</url>
+</cast_now>

--- a/tests/fixtures/cast_now_no_url.xml
+++ b/tests/fixtures/cast_now_no_url.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<cast_now version="120826" created="2017-11-18T19:22:01+0100" created_int="20171118192201">
+  <real_name>Voice of Hindu Kush</real_name>
+  <duration_h>1</duration_h>
+  <start_time>2019-01-27T14:00:00+01:00</start_time>
+  <end_time>2319-01-27T15:00:00+01:00</end_time>
+</cast_now>

--- a/tests/fixtures/cast_now_past_show.xml
+++ b/tests/fixtures/cast_now_past_show.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<cast_now version="120826" created="2017-11-18T19:22:01+0100" created_int="20171118192201">
+  <real_name>Voice of Hindu Kush</real_name>
+  <duration_h>1</duration_h>
+  <start_time>2019-01-27T14:00:00+01:00</start_time>
+  <end_time>2019-01-27T15:00:00+01:00</end_time>
+  <url>https://www.rabe.ch/stimme-der-kutuesch/</url>
+</cast_now>

--- a/tests/test_show.py
+++ b/tests/test_show.py
@@ -1,0 +1,51 @@
+from datetime import datetime
+
+import pytest
+import pytz
+
+from nowplaying.show import show
+
+
+class TestShow:
+    def test_init(self):
+        s = show.Show()
+        assert s.starttime == s.endtime
+
+    def test_name(self):
+        s = show.Show()
+        assert s.name is None
+        s.set_name("Test")
+        assert s.name == "Test"
+
+    def test_url(self):
+        s = show.Show()
+        assert s.url == show.DEFAULT_SHOW_URL
+        s.set_url("http://example.com/show")
+        assert s.url == "http://example.com/show"
+
+    def test_rabe_default_url(self):
+        assert show.DEFAULT_SHOW_URL == "https://www.rabe.ch"
+
+    def test_starttime(self):
+        s = show.Show()
+        t = datetime.now(pytz.timezone("UTC"))
+        o = s.starttime
+        s.set_starttime(t)
+        assert s.starttime == t
+        assert s.starttime != o
+        with pytest.raises(show.ShowError):
+            s.set_starttime("2019-01-01")
+
+    def test_endtime(self):
+        s = show.Show()
+        t = datetime.now(pytz.timezone("UTC"))
+        o = s.endtime
+        s.set_endtime(t)
+        assert s.endtime == t
+        assert s.endtime != o
+        with pytest.raises(show.ShowError):
+            s.set_endtime("2019-01-01")
+
+    def test_prettyprinting(self):
+        s = show.Show()
+        assert "Show 'None'" in str(s)

--- a/tests/test_show_client.py
+++ b/tests/test_show_client.py
@@ -1,0 +1,43 @@
+from datetime import datetime
+
+import mock
+import pytest
+import pytz
+
+from nowplaying.show import client
+
+
+class TestShowClient:
+    def test_init(self):
+        s = client.ShowClient("http://example.com")
+        assert s.current_show_url == "http://example.com"
+
+    @mock.patch("urllib.request.urlopen")
+    def test_update(self, mock_urlopen):
+        mock_urlopen.return_value = "tests/fixtures/cast_now_during_show.xml"
+        s = client.ShowClient("http://example.com")
+        s.update()
+        assert s.show.name == "Voice of Hindu Kush"
+        assert s.show.starttime == datetime(
+            2019, 1, 27, 13, tzinfo=pytz.timezone("UTC")
+        )
+        assert s.show.endtime == datetime(2319, 1, 27, 14, tzinfo=pytz.timezone("UTC"))
+        assert s.show.url == "https://www.rabe.ch/stimme-der-kutuesch/"
+
+    @mock.patch("urllib.request.urlopen")
+    def test_update_no_url(self, mock_urlopen):
+        mock_urlopen.return_value = "tests/fixtures/cast_now_no_url.xml"
+        s = client.ShowClient("http://example.com")
+        s.update()
+        assert s.show.url == "https://www.rabe.ch"
+
+    @mock.patch("urllib.request.urlopen")
+    def test_update_past_show(self, mock_urlopen):
+        mock_urlopen.return_value = "tests/fixtures/cast_now_past_show.xml"
+        s = client.ShowClient("http://example.com")
+        with pytest.raises(client.ShowClientError) as info:
+            s.update()
+        assert (
+            str(info.value)
+            == "Show end time (2019-01-27 14:00:00+00:00) is in the past"
+        )


### PR DESCRIPTION
This implements testing for the show parts. This only covers the happy paths of the code for the most parts as I expect this area to undergo some changes soon (see #12, #8).

With these tests I'm also removing some dead config code and fixing the "default url without http**s**" issue.