### PR TITLE
Move from elementtree.SimpleXMLWriter to lxml.etree

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytz==2017.2
-elementtree==1.2.6-20050316
 isodate==0.6.0
 pylast==3.0.0
+lxml==4.3.0

--- a/tests/test_track_observer_tickertrack.py
+++ b/tests/test_track_observer_tickertrack.py
@@ -1,0 +1,21 @@
+import os
+
+from nowplaying.show import show
+from nowplaying.track import observer, track
+
+
+class TestTickerTrackObserver:
+    def test_init(self):
+        o = observer.TickerTrackObserver(ticker_file_path="")
+        assert o.ticker_file_path == ""
+
+    def test_track_started(self):
+        o = observer.TickerTrackObserver(ticker_file_path="/tmp/track_started.xml")
+        t = track.Track()
+        t.set_artist("Hairmare and the Band")
+        t.set_title("An Ode to legacy Python Code")
+        t.set_album("Live at the Refactoring Club")
+        t.show = show.Show()
+        t.show.set_name("Hairmare Traveling Medicine Show")
+        o.track_started(t)
+        assert os.path.exists("/tmp/track_started.xml")


### PR DESCRIPTION
The SimpleXMLWriter thing isn't supported in py3 but lxml is. This also adds just enough tests so I was able to get up and running with the refactor.

I'm expecting some more refactoring to these bits at a later stage, this just aims at getting us to py3.