### PR TITLE
Build container image on ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,22 @@
 language: python
 python:
-  - "3.6"
-install:
-  - pip install -r requirements-dev.txt
-script:
-  - pytest --cov=nowplaying
+- '3.6'
+stages:
+- test
+- deploy
+jobs:
+  include:
+  - stage: test
+    name: pytest
+    install:
+    - pip install -r requirements-dev.txt
+    script:
+    - pytest --cov=nowplaying
+  - name: container image
+    services:
+    - docker
+    install:
+    - curl -L -O https://github.com/openshift/source-to-image/releases/download/v1.1.14/source-to-image-v1.1.14-874754de-linux-386.tar.gz
+    - tar xvf source-to-image-v1.1.14-874754de-linux-386.tar.gz ./s2i
+    script:
+    - "./s2i build --copy . registry.centos.org/centos/python-36-centos7 radiorabe/nowplaying:${TRAVIS_TAG:-${TRAVIS_COMMIT}}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Dockerfile from s2i --as-dockerfile output, checked in for convenience until we have
+# a proper docker registry that can securely be configured.
+# Currently hub.docker.io builds are based on this file so it should be updated if the
+# s2i base image is updated. In the long run this should get replaced with a toolchain
+# that runs docker builds on travis and then pushes them to a registry that allows for
+# pushing with an API key or token (like I'm assuming the github registry will allow).
+FROM registry.centos.org/centos/python-36-centos7
+LABEL "io.k8s.display-name"="now-playing" \
+      "io.openshift.s2i.build.image"="registry.centos.org/centos/python-36-centos7" \
+      "io.openshift.s2i.build.source-location"="."
+
+USER root
+# Copying in source code
+COPY upload/src /tmp/src
+# Change file ownership to the assemble user. Builder image must support chown command.
+RUN chown -R 1001:0 /tmp/src
+USER 1001
+# Assemble script sourced from builder image based on user input or image metadata.
+# If this file does not exist in the image, the build will fail.
+RUN /usr/libexec/s2i/assemble
+# Run script sourced from builder image based on user input or image metadata.
+# If this file does not exist in the image, the build will fail.
+CMD /usr/libexec/s2i/run


### PR DESCRIPTION
The changes to .travis.yml check to see if s2i can still build a container.

Sadly, docker hub does not support pushing images with anything else than a main docker account password in a secret. For that reason this PR includes a Dockerfile that can be used by docker hub to build some preliminary images. I plan on moving this to a different image and am currently considering the GitHub Container Registry since I'm assuming it will have a more fine grained permission model than docker hub (or quay.io for the matter).

Fixes #37 