### PR TITLE
Fix image building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ LABEL "io.k8s.display-name"="now-playing" \
 
 USER root
 # Copying in source code
-COPY upload/src /tmp/src
+COPY . /tmp/src
 # Change file ownership to the assemble user. Builder image must support chown command.
 RUN chown -R 1001:0 /tmp/src
 USER 1001


### PR DESCRIPTION
The base s2i tooling was preparing the sources in the upload/src before calling docker. This doesn't replicate that part of the s2i build but rather fixes the Dockerfile so we get something built that can be pulled from dockerhub. It is assumed that we will be getting rid of this Dockerfile once we have s2i building set up with OpenShift proper.

Fixes #37 