### PR TITLE
feat: refactor ShowClient to LibreTime v2 live-info API

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -5,6 +5,7 @@ on:
     branches-ignore:
       - main
       - gh-pages
+  pull_request:
 
 jobs:
   pre-commit:

--- a/nowplaying/options.py
+++ b/nowplaying/options.py
@@ -52,7 +52,7 @@ class Options(object):
             "--show",
             dest="currentShowUrl",
             help="Current Show URL",
-            default="http://intranet.rabe.ch/pub/show.php",
+            default="https://airtime.service.int.rabe.ch/api/live-info-v2/format/json",
         )
         self.__args.add_argument(
             "--input-file",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pytz==2021.3
 isodate==0.6.1
 pylast==4.4.0
 lxml==4.7.1
+requests==2.26.0

--- a/tests/fixtures/cast_now_during_show.json
+++ b/tests/fixtures/cast_now_during_show.json
@@ -1,0 +1,32 @@
+{
+  "station": {
+    "env": "production",
+    "schedulerTime": "2019-01-27 16:44:44",
+    "source_enabled": "Scheduled",
+    "timezone": "Europe/Zurich",
+    "AIRTIME_API_VERSION": "1.1"
+  },
+  "tracks": {
+    "previous": null,
+    "current": null,
+    "next": null
+  },
+  "shows": {
+    "previous": [
+
+    ],
+    "current": {
+      "name": "Voice of Hindu Kush",
+      "description": "",
+      "genre": "",
+      "id": 85,
+      "instance_id": 11605,
+      "record": 0,
+      "url": "https://www.rabe.ch/stimme-der-kutuesch/",
+      "image_path": "",
+      "starts": "2019-01-27 14:00:00",
+      "ends": "2319-01-27 15:00:00"
+    },
+    "next": []
+  }
+}

--- a/tests/fixtures/cast_now_during_show.xml
+++ b/tests/fixtures/cast_now_during_show.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0"?>
-<cast_now version="120826" created="2017-11-18T19:22:01+0100" created_int="20171118192201">
-  <real_name>Voice of Hindu Kush</real_name>
-  <duration_h>1</duration_h>
-  <start_time>2019-01-27T14:00:00+01:00</start_time>
-  <end_time>2319-01-27T15:00:00+01:00</end_time>
-  <url>https://www.rabe.ch/stimme-der-kutuesch/</url>
-</cast_now>

--- a/tests/fixtures/cast_now_no_end.json
+++ b/tests/fixtures/cast_now_no_end.json
@@ -1,0 +1,32 @@
+{
+  "station": {
+    "env": "production",
+    "schedulerTime": "2019-01-27 16:44:44",
+    "source_enabled": "Scheduled",
+    "timezone": "Europe/Zurich",
+    "AIRTIME_API_VERSION": "1.1"
+  },
+  "tracks": {
+    "previous": null,
+    "current": null,
+    "next": null
+  },
+  "shows": {
+    "previous": [
+
+    ],
+    "current": {
+      "name": "Voice of Hindu Kush",
+      "description": "",
+      "genre": "",
+      "id": 85,
+      "instance_id": 11605,
+      "record": 0,
+      "url": "https://www.rabe.ch/stimme-der-kutuesch/",
+      "image_path": "",
+      "starts": "2019-01-27 14:00:00",
+      "ends": ""
+    },
+    "next": []
+  }
+}

--- a/tests/fixtures/cast_now_no_name.json
+++ b/tests/fixtures/cast_now_no_name.json
@@ -1,0 +1,32 @@
+{
+  "station": {
+    "env": "production",
+    "schedulerTime": "2019-01-27 16:44:44",
+    "source_enabled": "Scheduled",
+    "timezone": "Europe/Zurich",
+    "AIRTIME_API_VERSION": "1.1"
+  },
+  "tracks": {
+    "previous": null,
+    "current": null,
+    "next": null
+  },
+  "shows": {
+    "previous": [
+
+    ],
+    "current": {
+      "name": "",
+      "description": "",
+      "genre": "",
+      "id": 85,
+      "instance_id": 11605,
+      "record": 0,
+      "url": "https://www.rabe.ch/stimme-der-kutuesch/",
+      "image_path": "",
+      "starts": "2019-01-27 14:00:00",
+      "ends": "2319-01-27 15:00:00"
+    },
+    "next": []
+  }
+}

--- a/tests/fixtures/cast_now_no_start.json
+++ b/tests/fixtures/cast_now_no_start.json
@@ -1,0 +1,32 @@
+{
+  "station": {
+    "env": "production",
+    "schedulerTime": "2019-01-27 16:44:44",
+    "source_enabled": "Scheduled",
+    "timezone": "Europe/Zurich",
+    "AIRTIME_API_VERSION": "1.1"
+  },
+  "tracks": {
+    "previous": null,
+    "current": null,
+    "next": null
+  },
+  "shows": {
+    "previous": [
+
+    ],
+    "current": {
+      "name": "Voice of Hindu Kush",
+      "description": "",
+      "genre": "",
+      "id": 85,
+      "instance_id": 11605,
+      "record": 0,
+      "url": "https://www.rabe.ch/stimme-der-kutuesch/",
+      "image_path": "",
+      "starts": "",
+      "ends": "2319-01-27 15:00:00"
+    },
+    "next": []
+  }
+}

--- a/tests/fixtures/cast_now_no_url.json
+++ b/tests/fixtures/cast_now_no_url.json
@@ -1,0 +1,32 @@
+{
+  "station": {
+    "env": "production",
+    "schedulerTime": "2019-01-27 16:44:44",
+    "source_enabled": "Scheduled",
+    "timezone": "Europe/Zurich",
+    "AIRTIME_API_VERSION": "1.1"
+  },
+  "tracks": {
+    "previous": null,
+    "current": null,
+    "next": null
+  },
+  "shows": {
+    "previous": [
+
+    ],
+    "current": {
+      "name": "Voice of Hindu Kush",
+      "description": "",
+      "genre": "",
+      "id": 85,
+      "instance_id": 11605,
+      "record": 0,
+      "url": "",
+      "image_path": "",
+      "starts": "2019-01-27 14:00:00",
+      "ends": "2319-01-27 15:00:00"
+    },
+    "next": []
+  }
+}

--- a/tests/fixtures/cast_now_no_url.xml
+++ b/tests/fixtures/cast_now_no_url.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0"?>
-<cast_now version="120826" created="2017-11-18T19:22:01+0100" created_int="20171118192201">
-  <real_name>Voice of Hindu Kush</real_name>
-  <duration_h>1</duration_h>
-  <start_time>2019-01-27T14:00:00+01:00</start_time>
-  <end_time>2319-01-27T15:00:00+01:00</end_time>
-</cast_now>

--- a/tests/fixtures/cast_now_past_show.json
+++ b/tests/fixtures/cast_now_past_show.json
@@ -1,0 +1,32 @@
+{
+  "station": {
+    "env": "production",
+    "schedulerTime": "2019-01-27 16:44:44",
+    "source_enabled": "Scheduled",
+    "timezone": "Europe/Zurich",
+    "AIRTIME_API_VERSION": "1.1"
+  },
+  "tracks": {
+    "previous": null,
+    "current": null,
+    "next": null
+  },
+  "shows": {
+    "previous": [
+
+    ],
+    "current": {
+      "name": "Voice of Hindu Kush",
+      "description": "",
+      "genre": "",
+      "id": 85,
+      "instance_id": 11605,
+      "record": 0,
+      "url": "https://www.rabe.ch/stimme-der-kutuesch/",
+      "image_path": "",
+      "starts": "2019-01-27 14:00:00",
+      "ends": "2019-01-27 15:00:00"
+    },
+    "next": []
+  }
+}

--- a/tests/fixtures/cast_now_past_show.xml
+++ b/tests/fixtures/cast_now_past_show.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0"?>
-<cast_now version="120826" created="2017-11-18T19:22:01+0100" created_int="20171118192201">
-  <real_name>Voice of Hindu Kush</real_name>
-  <duration_h>1</duration_h>
-  <start_time>2019-01-27T14:00:00+01:00</start_time>
-  <end_time>2019-01-27T15:00:00+01:00</end_time>
-  <url>https://www.rabe.ch/stimme-der-kutuesch/</url>
-</cast_now>

--- a/tests/fixtures/cast_now_show_empty.json
+++ b/tests/fixtures/cast_now_show_empty.json
@@ -1,0 +1,19 @@
+{
+  "station": {
+    "env": "production",
+    "schedulerTime": "2019-01-27 16:44:44",
+    "source_enabled": "Scheduled",
+    "timezone": "Europe/Zurich",
+    "AIRTIME_API_VERSION": "1.1"
+  },
+  "tracks": {
+    "previous": null,
+    "current": null,
+    "next": null
+  },
+  "shows": {
+    "previous": [],
+    "current": {},
+    "next": []
+  }
+}

--- a/tests/test_show_client.py
+++ b/tests/test_show_client.py
@@ -1,21 +1,33 @@
+import json
 from datetime import datetime
+from unittest.mock import Mock
 
 import mock
 import pytest
 import pytz
+import requests
 
 from nowplaying.show import client
 
 
+def file_get_contents(filename):
+    with open(filename) as f:
+        return f.read()
+
+
 class TestShowClient:
     def test_init(self):
-        s = client.ShowClient("http://example.com")
-        assert s.current_show_url == "http://example.com"
+        s = client.ShowClient("http://example.com/api/live-info-v2/format/json")
+        assert s.current_show_url == "http://example.com/api/live-info-v2/format/json"
 
-    @mock.patch("urllib.request.urlopen")
-    def test_update(self, mock_urlopen):
-        mock_urlopen.return_value = "tests/fixtures/cast_now_during_show.xml"
-        s = client.ShowClient("http://example.com")
+    @mock.patch("requests.get")
+    def test_update(self, mock_requests_get):
+        mock_requests_get.return_value.json = Mock(
+            return_value=json.loads(
+                file_get_contents("tests/fixtures/cast_now_during_show.json")
+            )
+        )
+        s = client.ShowClient("http://example.com/api/live-info-v2/format/json")
         s.update()
         assert s.show.name == "Voice of Hindu Kush"
         assert s.show.starttime == datetime(
@@ -24,20 +36,68 @@ class TestShowClient:
         assert s.show.endtime == datetime(2319, 1, 27, 14, tzinfo=pytz.timezone("UTC"))
         assert s.show.url == "https://www.rabe.ch/stimme-der-kutuesch/"
 
-    @mock.patch("urllib.request.urlopen")
-    def test_update_no_url(self, mock_urlopen):
-        mock_urlopen.return_value = "tests/fixtures/cast_now_no_url.xml"
-        s = client.ShowClient("http://example.com")
+    @mock.patch("requests.get")
+    def test_update_connection_error(self, mock_requests_get):
+        """Don't crash if external api refuses to connect."""
+        mock_requests_get.side_effect = requests.exceptions.ConnectionError()
+        s = client.ShowClient("http://example.com/api/live-info-v2/format/json")
+        s.update()
+        assert s.show.name is None
+        assert s.show.url == "https://www.rabe.ch"
+
+    @mock.patch("requests.get")
+    def test_update_no_url(self, mock_requests_get):
+        mock_requests_get.return_value.json = Mock(
+            return_value=json.loads(
+                file_get_contents("tests/fixtures/cast_now_no_url.json")
+            )
+        )
+        s = client.ShowClient("http://example.com/api/live-info-v2/format/json")
         s.update()
         assert s.show.url == "https://www.rabe.ch"
 
-    @mock.patch("urllib.request.urlopen")
-    def test_update_past_show(self, mock_urlopen):
-        mock_urlopen.return_value = "tests/fixtures/cast_now_past_show.xml"
-        s = client.ShowClient("http://example.com")
+    @mock.patch("requests.get")
+    @pytest.mark.parametrize(
+        "fixture,field",
+        [
+            ("cast_now_no_name", "name"),
+            ("cast_now_no_end", "end time"),
+            ("cast_now_no_start", "start time"),
+        ],
+    )
+    def test_update_empty_field(self, mock_requests_get, fixture, field):
+        mock_requests_get.return_value.json = Mock(
+            return_value=json.loads(file_get_contents(f"tests/fixtures/{fixture}.json"))
+        )
+        s = client.ShowClient("http://example.com/api/live-info-v2/format/json")
+        with pytest.raises(client.ShowClientError) as info:
+            s.update()
+        assert str(info.value) == f"Missing show {field}"
+
+    @mock.patch("requests.get")
+    def test_update_past_show(self, mock_requests_get):
+        mock_requests_get.return_value.json = Mock(
+            return_value=json.loads(
+                file_get_contents("tests/fixtures/cast_now_past_show.json")
+            )
+        )
+        s = client.ShowClient("http://example.com/api/live-info-v2/format/json")
         with pytest.raises(client.ShowClientError) as info:
             s.update()
         assert (
             str(info.value)
             == "Show end time (2019-01-27 14:00:00+00:00) is in the past"
         )
+
+    @mock.patch("requests.get")
+    def test_update_show_empty(self, mock_requests_get):
+        """Should not crash if external api has no info."""
+        mock_requests_get.return_value.json = Mock(
+            return_value=json.loads(
+                file_get_contents("tests/fixtures/cast_now_show_empty.json")
+            )
+        )
+        s = client.ShowClient("http://example.com/api/live-info-v2/format/json")
+        s.update()
+        assert s.show.name is None
+        assert s.show.url == "https://www.rabe.ch"


### PR DESCRIPTION
# Description

Refactor `ShowClient` to target the LibreTime v2 live-info JSON API directly instead of using the wrapper described in #12.

Introduces [`requests`](https://docs.python-requests.org/en/latest/) to make handling web requests easier with more abstraction.

With this, test-coverage of the `nowplaying/show/client.py:update` function is now up to 100%.

# Issues

- Fixes #12