### PR TITLE
fix: cleanup entitites in show json from libretime

### DIFF
--- a/tests/fixtures/cast_now_show_encoding_fix.json
+++ b/tests/fixtures/cast_now_show_encoding_fix.json
@@ -1,0 +1,30 @@
+{
+  "station": {
+    "env": "production",
+    "schedulerTime": "2019-01-27 16:44:44",
+    "source_enabled": "Scheduled",
+    "timezone": "Europe/Zurich",
+    "AIRTIME_API_VERSION": "1.1"
+  },
+  "tracks": {
+    "previous": null,
+    "current": null,
+    "next": null
+  },
+  "shows": {
+    "previous": [],
+    "current": {
+      "name": "Rhythm &amp; Blues Juke Box &ouml;&ccedil;",
+      "description": "",
+      "genre": "",
+      "id": 85,
+      "instance_id": 11605,
+      "record": 0,
+      "url": "https://rabe.ch/rhythm-blues-juke-box/",
+      "image_path": "",
+      "starts": "2019-01-27 14:00:00",
+      "ends": "2319-01-27 15:00:00"
+    },
+    "next": []
+  }
+}

--- a/tests/test_show_client.py
+++ b/tests/test_show_client.py
@@ -173,3 +173,16 @@ def test_update_show_empty(mock_requests_get):
     show_client.update()
     assert show_client.show.name is None
     assert show_client.show.url == "https://www.rabe.ch"
+
+
+@mock.patch("requests.get")
+def test_update_show_encoding_fix_in_name(mock_requests_get):
+    """Test :class:`ShowClient`'s :meth:`update` method when the show name has an encoding fix."""
+    mock_requests_get.return_value.json = Mock(
+        return_value=json.loads(
+            file_get_contents("tests/fixtures/cast_now_show_encoding_fix.json")
+        )
+    )
+    show_client = ShowClient(_BASE_URL)
+    show_client.update()
+    assert show_client.show.name == "Rhythm & Blues Juke Box öç"


### PR DESCRIPTION
Fix #151 

I guess the release gets to be called [revenge](https://en.wiktionary.org/wiki/%C3%B6%C3%A7) of the ampersand due to test string i randomly chose 😁 