### PR TITLE
fix: pick next show if it starts reasonably soon

### DIFF
--- a/tests/fixtures/cast_now_show_encoding_fix.json
+++ b/tests/fixtures/cast_now_show_encoding_fix.json
@@ -14,7 +14,7 @@
   "shows": {
     "previous": [],
     "current": {
-      "name": "Rhythm &amp; Blues Juke Box &ouml;&ccedil;",
+      "name": "Rhythm &amp; Blues Juke Box &ouml;&ccedil; &nope;",
       "description": "",
       "genre": "",
       "id": 85,

--- a/tests/fixtures/cast_now_show_in_next.json
+++ b/tests/fixtures/cast_now_show_in_next.json
@@ -1,0 +1,32 @@
+{
+  "station": {
+    "env": "production",
+    "schedulerTime": "2019-01-27 16:44:44",
+    "source_enabled": "Scheduled",
+    "timezone": "Europe/Zurich",
+    "AIRTIME_API_VERSION": "1.1"
+  },
+  "tracks": {
+    "previous": null,
+    "current": null,
+    "next": null
+  },
+  "shows": {
+    "previous": [],
+    "current": null,
+    "next": [
+      {
+        "name": "Voice of Hindu Kush",
+        "description": "",
+        "genre": "",
+        "id": 85,
+        "instance_id": 11605,
+        "record": 0,
+        "url": "https://www.rabe.ch/stimme-der-kutuesch/",
+        "image_path": "",
+        "starts": "2019-01-27 14:00:00",
+        "ends": "2319-01-27 15:00:00"
+      }
+    ]
+  }
+}

--- a/tests/test_show_client.py
+++ b/tests/test_show_client.py
@@ -185,4 +185,24 @@ def test_update_show_encoding_fix_in_name(mock_requests_get):
     )
     show_client = ShowClient(_BASE_URL)
     show_client.update()
-    assert show_client.show.name == "Rhythm & Blues Juke Box öç"
+    assert show_client.show.name == "Rhythm & Blues Juke Box öç &nope;"
+
+
+@mock.patch("requests.get")
+def test_update_when_show_is_in_next_array(mock_requests_get):
+    """Test :class:`ShowClient`'s :meth:`update` method."""
+    mock_requests_get.return_value.json = Mock(
+        return_value=json.loads(
+            file_get_contents("tests/fixtures/cast_now_show_in_next.json")
+        )
+    )
+    show_client = ShowClient(_BASE_URL)
+    show_client.update()
+    assert show_client.show.name == "Voice of Hindu Kush"
+    assert show_client.show.starttime == datetime(
+        2019, 1, 27, 13, tzinfo=pytz.timezone("UTC")
+    )
+    assert show_client.show.endtime == datetime(
+        2319, 1, 27, 14, tzinfo=pytz.timezone("UTC")
+    )
+    assert show_client.show.url == "https://www.rabe.ch/stimme-der-kutuesch/"


### PR DESCRIPTION
This adds a hacky method that picks the next show from Libretimes response if the next show end in < 15 minutes.

For the most part this help when we request the show before `current` has any data at the top of the hour. It also makes it possible for show to end early without us sending too many finished events.

In the long run we'll want something more evented based on showStarted and showFinished events. For now this helps send better tags when a preprogrammed show follows right after Klangbecken (DL+ for those shows never made it to receivers because it was being replaced to fast).

Fixes #160 (it's not the only part of the fix but should be the final one)