### PR TITLE
fix: ignore anything under 5 seconds for DAB DLS purposes

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -30,11 +30,13 @@ def new_track(
     artist="Hairmare and the Band",
     title="An Ode to legacy Python Code",
     album="Live at the Refactoring Club",
+    duration=128,
 ):
     t = Track()
     t.set_artist(artist)
     t.set_title(title)
     t.set_album(album)
+    t.set_duration(duration)
     return t
 
 

--- a/nowplaying/track/observers/dab_audio_companion.py
+++ b/nowplaying/track/observers/dab_audio_companion.py
@@ -1,8 +1,10 @@
 import logging
 import urllib
+from datetime import timedelta
 
 import requests
 
+from ..track import Track
 from .base import TrackObserver
 
 logger = logging.getLogger(__name__)
@@ -21,7 +23,7 @@ class DabAudioCompanionTrackObserver(TrackObserver):
             % (self.base_url, self.dls_enabled)
         )
 
-    def track_started(self, track):
+    def track_started(self, track: Track):
         logger.info(
             "Updating DAB+ DLS for track: %s - %s" % (track.artist, track.title)
         )
@@ -30,6 +32,12 @@ class DabAudioCompanionTrackObserver(TrackObserver):
             return self._track_started_plain(track)
 
         params = {}
+
+        if track.get_duration() < timedelta(seconds=5):
+            logger.info(
+                "Track is less than 5 seconds, not sending to DAB+ Audio Companion"
+            )
+            return
 
         if not track.has_default_title() and not track.has_default_artist():
             params["artist"] = track.artist

--- a/nowplaying/track/track.py
+++ b/nowplaying/track/track.py
@@ -81,7 +81,7 @@ class Track:
         self.show = show
 
     def get_duration(self):
-        return self.starttime - self.endtime
+        return self.endtime - self.starttime
 
     def has_default_artist(self):
         if self.artist == DEFAULT_ARTIST:

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -96,7 +96,7 @@ def test_duration():
     track = Track()
     assert track.get_duration() == timedelta(0)
     track.set_duration(60)
-    assert track.get_duration() == timedelta(-1, 86340)
+    assert track.get_duration() == timedelta(seconds=60)
 
 
 def test_prettyprinting():

--- a/tests/test_track_observer_dabaudiocompanion.py
+++ b/tests/test_track_observer_dabaudiocompanion.py
@@ -77,6 +77,12 @@ def test_track_started(mock_requests_post, track_factory, show_factory):
         {"dls": "Radio Bern - Hairmare Traveling Medicine Show"},
     )
 
+    # check that short tracks dont get sent
+    track = track_factory(artist="Radio Bern", title="Livestream", duration=3)
+    mock_requests_post.reset_mock()
+    dab_audio_companion_track_observer.track_started(track)
+    mock_requests_post.assert_not_called()
+
 
 @patch("urllib.request.urlopen")
 def test_track_started_plain(mock_urlopen, track_factory, show_factory):


### PR DESCRIPTION
The idea is to not "spam" any worthless DL+ frames by cutting off anything that is not gonna be on air for an important length of time. I didn't do anything empiracal to get to 5 seconds (and feel free to improve on this) but it's pretty clear that we need to investigate how often it makes sense to update dl+ for typical receivers.

5 seconds is still a very low value for this, but it's better than nothing, i'll make this configurable an revisit it later when i deeper dive into #157 

* #157 