### PR TITLE
chore: multi-stage build and install as wheel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN    cd /app \
 
 FROM ghcr.io/radiorabe/python-minimal:0.2.1 AS app
 
-COPY /app/dist/*.whl /tmp/dist/
+COPY --from=build /app/dist/*.whl /tmp/dist/
 
 RUN    python3 -mpip --no-cache-dir install /tmp/dist/*.whl \
     && rm -rf /tmp/dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,19 @@
-FROM ghcr.io/radiorabe/python-minimal:0.2.1
+FROM ghcr.io/radiorabe/python-minimal:0.2.1 AS build
 
 COPY ./ /app/
 
 RUN    cd /app \
     && microdnf install git-core | tee > /tmp/install.log \
-    && python3 -mpip --no-cache-dir install setuptools-git-versioning \
-    && python3 -mpip --no-cache-dir install . \
-    && microdnf remove `awk '/^Installing: [a-zA-Z]+/ {print $2}' /tmp/install.log | awk -F ';' '{printf $1 " "}'` \
-    && microdnf clean all \
-    && rm -rf /app/ /tmp/install.log
+    && python3 -mpip --no-cache-dir install setuptools-git-versioning wheel \
+    && python3 setup.py bdist_wheel
+
+
+FROM ghcr.io/radiorabe/python-minimal:0.2.1 AS app
+
+COPY /app/dist/*.whl /tmp/dist/
+
+RUN    python3 -mpip --no-cache-dir install /tmp/dist/*.whl \
+    && rm -rf /tmp/dist/
 
 # make requests use os ca certs that contain the RaBe root CA
 ENV REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem


### PR DESCRIPTION
This gets rid of the awkward `microdnf remove` step without increasing the build time too much and there is also some potential performance gain to be had from a wheel based installation.