### PR TITLE
chore: use s2i-python to build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,13 @@
-FROM ghcr.io/radiorabe/python-minimal:0.2.3 AS build
+FROM ghcr.io/radiorabe/s2i-python:0.1.1 AS build
 
-COPY ./ /app/
+COPY ./ /opt/app-root/src
 
-RUN    cd /app \
-    && echo -n "Python Version: " \
-    && python -V \
-    && microdnf install git-core | tee > /tmp/install.log \
-    && python3 -mpip --no-cache-dir install setuptools-git-versioning wheel \
-    && python3 setup.py bdist_wheel
+RUN python3 setup.py bdist_wheel
 
 
 FROM ghcr.io/radiorabe/python-minimal:0.2.3 AS app
 
-COPY --from=build /app/dist/*.whl /tmp/dist/
+COPY --from=build /opt/app-root/src/dist/*.whl /tmp/dist/
 
 RUN    python3 -mpip --no-cache-dir install /tmp/dist/*.whl \
     && rm -rf /tmp/dist/


### PR DESCRIPTION
Simplify build by using [RaBe S2I Python Minimal Image](https://github.com/radiorabe/container-image-rabe-s2i-python-minimal) as build image (already contains git and wheel).