### PR TITLE
feat: add STATIONNAME.LONG object in artist/title delete message

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ cloudevents==1.8.0
 ConfigArgParse==1.5.3
 isodate==0.6.1
 lxml==4.9.2
+nowplaypadgen==0.4.8
 opentelemetry-api==1.15.0
 opentelemetry-exporter-otlp==1.15.0
 opentelemetry-sdk==1.15.0


### PR DESCRIPTION
We regularly send DL+ delete messages when we don't have anymore data from Klangbecken. This change uses the nowplaypadgen module to generate these delete messages and also grabs the opportunity to tag the `STATIONNAME.LONG` in them.

* prep/experimental work for #154 