### PR TITLE
chore(ci): group dependabot PRs for opentelemetry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
       prefix: "feat(deps): "
       prefix-development: "chore(deps): "
     open-pull-requests-limit: 20
+    groups:
+      opentelemetry:
+        - "opentelemetry-*"
 
   # Update Dockerfile
   - package-ecosystem: "docker"


### PR DESCRIPTION
* https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/