### PR TITLE
fix(saemubox): flag to disable src ip check

### DIFF
--- a/nowplaying/daemon.py
+++ b/nowplaying/daemon.py
@@ -30,7 +30,9 @@ class NowPlayingDaemon:
         self.options = options
 
         self.event_queue = Queue()
-        self.saemubox = SaemuBox(self.options.saemubox_ip)
+        self.saemubox = SaemuBox(
+            self.options.saemubox_ip, self.options.check_saemubox_sender
+        )
 
     def main(self):  # pragma: no cover
         # TODO test once there is not saemubox in the loop

--- a/nowplaying/misc/saemubox.py
+++ b/nowplaying/misc/saemubox.py
@@ -34,7 +34,7 @@ class SaemuBox:
         6: "Studio Live",
     }
 
-    def __init__(self, saemubox_ip):
+    def __init__(self, saemubox_ip, check_sender=True):
         warnings.warn(
             "Saemubox will be replaced with Pathfinder", PendingDeprecationWarning
         )
@@ -48,6 +48,9 @@ class SaemuBox:
 
         # allowed sender ip addresses
         self.senders = {saemubox_ip}
+
+        # check self.senders for validity
+        self.check_sender = check_sender
 
         # valid saemubox ids
         self.valid_ids = [str(i) for i in self.output_mapping]
@@ -79,7 +82,7 @@ class SaemuBox:
         # read from socket while there is something to read (non-blocking)
         while select.select([self.sock], [], [], 0)[0]:
             data, addr = self.sock.recvfrom(1024)
-            if addr[0] not in self.senders:
+            if self.check_sender and addr[0] not in self.senders:
                 logger.warn("SaemuBox: receiving data from invalid host: %s " % addr[0])
                 continue
 

--- a/nowplaying/options.py
+++ b/nowplaying/options.py
@@ -21,12 +21,20 @@ class Options:
         self.__args = configargparse.ArgParser(
             default_config_files=["/etc/nowplaying/conf.d/*.conf", "~/.nowplayingrc"]
         )
+        # TODO v3 remove this option
         self.__args.add_argument(
             "-b",
             "--saemubox-ip",
             dest="saemubox_ip",
             help="IP address of SAEMUBOX",
             default="",
+        )
+        # TODO v3 remove this option
+        self.__args.add_argument(
+            "--check-saemubox-sender",
+            dest="check_saemubox_sender",
+            help="Check SRC SAEMUBOX IP",
+            default=True,
         )
         IcecastTrackObserver.Options.args(self.__args)
         DabAudioCompanionTrackObserver.Options.args(self.__args)

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -15,6 +15,7 @@ def fixture_options():
     class _Options:
         def __init__(self):
             self.saemubox_ip = ""
+            self.check_saemubox_sender = True
 
     return _Options()
 


### PR DESCRIPTION
This is due to the fact that the virtual saemubox will have a new IP on each restart when scheduled with podman.