### PR TITLE
fix: pin timezone to Europe/Zurich

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ RUN    microdnf install -y \
          python3.11-pip \
          python3.11-setuptools \
     && microdnf clean all \
-    && rm -rf /tmp/dist/
+    && rm -rf /tmp/dist/ \
+    && rm -rf /etc/localtime \
+    && ln -s ../usr/share/zoneinfo/Europe/Zurich /etc/localtime
 
 # make requests use os ca certs that contain the RaBe root CA
 ENV REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem


### PR DESCRIPTION
This is a workaround for podman not currently supporting the `--tz` flag in kube manifests
