### PR TITLE
chore(ci): configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,7 @@ updates:
     directory: /
     schedule:
       interval: daily
+    groups:
+      opentelemetry:
+        patterns:
+          - "opentelemetry-*"


### PR DESCRIPTION
# Initialize [GitHub Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates).

Configures Dependabot to create regular update PRs.
